### PR TITLE
Use a better way to create the x-locations.

### DIFF
--- a/NST_FlumeExample.ipynb
+++ b/NST_FlumeExample.ipynb
@@ -75,13 +75,10 @@
     "link_len = 100  # meters \n",
     "num_links = 15\n",
     "\n",
-    "x_of_node = np.arange(0, link_len*num_links+1, link_len) # x coordinates of nodes\n",
-    "y_of_node = np.ones_like(x_of_node)  # y coordinates of nodes\n",
+    "x_of_node = [ link_len*i for i in range(0, num_links+1) ] # x coordinates of nodes\n",
+    "y_of_node = [ 1          for i in range(0, num_links+1) ] # y coordinates of nodes (all equal to 1)\n",
     "\n",
-    "nodes_at_link = []\n",
-    "for i in range(np.size(y_of_node)-1):\n",
-    "    nodes_at_link.append((i, i+1))\n",
-    "\n",
+    "nodes_at_link = [ (i,i+1) for i in range(0, num_links+1) ]\n",
     "grid = NetworkModelGrid((y_of_node, x_of_node), nodes_at_link)"
    ]
   },


### PR DESCRIPTION
The existing code builds the x-locations of nodes via the code
```
x_of_node = np.arange(0, link_len*num_links+1, link_len)
```
I got confused by the `+1`. What the code really is doing is created an array of equally spaced nodes between zero and `link_len*num_links`, including the two end points. `np.arange()` takes the lower and upper bounds as arguments, and then the `delta_x`, but treats the upper bound as exclusive. So if you want the end point as part of the array, you need to use `upper_bound plus a little bit`, where "a little bit" here is chosen as 1. If you know what the code does, that's clear, but you have to know how `np.arange` works to understand this. You must also be careful to choose "a little bit" as less than the increment (here, `link_len`) -- which here is the case, but the code won't run correctly if someone chosen `link_len=0.9`, for example.

This can be done more concisely by creating the list using list comprehension directly. While there, do the same for the y values as well as for the list of links.